### PR TITLE
Merge Indexes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,8 @@ local_settings.py
 .vscode
 .DS_store
 __pycache__
+
+# files moved by Sphinx builder
+aide_doc/form_submit/templates/docs/Entrance_Tank/*
+aide_doc/form_submit/templates/docs/Introduction/*
+aide_doc/form_submit/templates/docs/index.rst

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ __pycache__
 aide_doc/form_submit/templates/docs/Entrance_Tank/*
 aide_doc/form_submit/templates/docs/Introduction/*
 aide_doc/form_submit/templates/docs/index.rst
+aide_doc/form_submit/templates/docs/new_index.rst

--- a/aide_doc/form_submit/templates/docs/conf.py
+++ b/aide_doc/form_submit/templates/docs/conf.py
@@ -218,12 +218,10 @@ rst_prolog = """
 .. role:: red
 """
 
-# Here's a function to define custom styles to be used with the roles:
 def setup(app):
-    # parsed_measurements = get_parsed_measurements("https://cad.onshape.com/documents/c3a8ce032e33ebe875b9aab4/w/de9ad5474448b34f33fef097/e/1336f29c2649ad86aceaeaeb")
     parsed_measurements, templates = parse.get_parsed_measurements(settings.link)
-    # TODO: add way to retrieve file/path from Documenter
+
     for template in templates:
-        parse.make_replace_file(parsed_measurements, template)
+        parse.make_replace_list(parsed_measurements, template)
 
     app.add_stylesheet('css/custom.css')

--- a/aide_doc/form_submit/templates/docs/conf.py
+++ b/aide_doc/form_submit/templates/docs/conf.py
@@ -221,8 +221,9 @@ rst_prolog = """
 # Here's a function to define custom styles to be used with the roles:
 def setup(app):
     # parsed_measurements = get_parsed_measurements("https://cad.onshape.com/documents/c3a8ce032e33ebe875b9aab4/w/de9ad5474448b34f33fef097/e/1336f29c2649ad86aceaeaeb")
-    parsed_measurements = parse.get_parsed_measurements(settings.link)
+    parsed_measurements, templates = parse.get_parsed_measurements(settings.link)
     # TODO: add way to retrieve file/path from Documenter
-    parse.make_replace_file(parsed_measurements, './Entrance_Tank/LFOM.rst')
+    for template in templates:
+        parse.make_replace_file(parsed_measurements, template)
 
     app.add_stylesheet('css/custom.css')

--- a/aide_doc/form_submit/templates/docs/parse.py
+++ b/aide_doc/form_submit/templates/docs/parse.py
@@ -252,10 +252,6 @@ def parse_variables_from_map(unparsed, default_key):
                 copyfile(unparsed, 'index.rst')
         return parsed_variables, templates
     elif default_key == "process":
-        # write function to download that process
-        # name it treatmentprocess.rst unless treatmentproecss.rst already exists
-        # if treatmentprocss.rst is not None:
-            # merge_treatment_processes(treatmentprocess.rst, newprocess.rst
         if unparsed != "" and unparsed is not None:
             file = "Introduction/Treatment_Process.rst"
             file_path = "../../../../doc_files/Introduction/Treatment_Process_" + unparsed + ".rst"

--- a/aide_doc/form_submit/templates/docs/parse.py
+++ b/aide_doc/form_submit/templates/docs/parse.py
@@ -85,7 +85,7 @@ def is_fs_type(candidate, type_name):
         result: True if candidate is of type_name, False otherwise
 
     >>> import json
-    >>> test_json = json.loads("{'type': 2077, 'typeName': 'BTFSValueMapEntry', 'message': {}}")
+    >>> test_json = json.loads('{"type": 2077, "typeName": "BTFSValueMapEntry", "message": {}}')
     >>> is_fs_type(test_json, "BTFSValueWithUnits")
     True
     >>> is_fs_type(test_json, "BTFSValueNumber")
@@ -224,7 +224,7 @@ def merge_indexes(new_index, old_index):
         none
 
     >>> old_index = '../../../../test_files/index_lfom.rst'
-    >>> new_index = '../../../../test_files/index_ET.rst'
+    >>> new_index = '../../../../test_files/new_index.rst'
     >>> merge_indexes(new_index, old_index)
     >>> index_file = open(old_index, "r+")
     >>> lines = index_file.readlines()
@@ -279,8 +279,8 @@ def find_treatment_section_limits(filename, section_delimiter=".. heading"):
     >>> _, limits = find_treatment_section_limits(process)
     >>> limits
     [[16, 21]]
-    >>> index = '../../../../test_files/Treatment_Process_ET_Floc.rst'
-    >>> _, limits = find_treatment_section_limits(index)
+    >>> process = '../../../../test_files/Treatment_Process_ET_Floc.rst'
+    >>> _, limits = find_treatment_section_limits(process)
     >>> limits
     [[16, 21], [22, 27]]
     """
@@ -460,19 +460,19 @@ def get_parsed_measurements(link):
     >>> link = 'https://cad.onshape.com/documents/c3a8ce032e33ebe875b9aab4/v/2990aab7c08553622d0c1402/e/e09d11406e7a9143537efe3a'
     >>> measurements, templates = get_parsed_measurements(link)
     >>> templates
-    ['./Entrance_Tank/Tank_Design_Algorithm.rst' , './Entrance_Tank/LFOM.rst']
+    ['./Entrance_Tank/LFOM.rst', './Entrance_Tank/Tank_Design_Algorithm.rst']
     >>> measurements['W.Et']
-    64.1 cm
-    >>> measurements['LfomOrifices']
-    13.0, 3.0, 4.0, 4.0]
+    '64.1 cm'
+    >>> measurements['N.LfomOrifices']
+    [13.0, 3.0, 4.0, 4.0]
     >>> measurements['HL.Lfom']
-    20.0 cm
+    '20.0 cm'
     >>> measurements['H.LfomOrifices']
     ['2.22 cm', '7.41 cm', '12.59 cm', '17.78 cm']
     >>> measurements['D.LfomOrifices']
-    4.45 cm
+    '4.45 cm'
     >>> measurements['B.LfomRows']
-    5.0 cm
+    '5.0 cm'
     """
     script = r"""
         function (context is Context, queries is map)

--- a/aide_doc/form_submit/templates/docs/parse.py
+++ b/aide_doc/form_submit/templates/docs/parse.py
@@ -86,7 +86,7 @@ def is_fs_type(candidate, type_name):
 
     >>> import json
     >>> test_json = json.loads('{"type": 2077, "typeName": "BTFSValueMapEntry", "message": {}}')
-    >>> is_fs_type(test_json, "BTFSValueWithUnits")
+    >>> is_fs_type(test_json, "BTFSValueMapEntry")
     True
     >>> is_fs_type(test_json, "BTFSValueNumber")
     False
@@ -155,12 +155,19 @@ def merge_index_sections(new_section, old_section):
 
     Returns:
         none
+
+    >>> new_section = ['test_line', 'test_line2']
+    >>> old_section = ['test_line', 'test_line3']
+    >>> merge_index_sections(new_section, old_section)
+    ['test_line', 'test_line2', 'test_line3']
     """
     for line in old_section:
         if line in new_section:
             continue
         else:
             new_section.append(line)
+
+    return new_section
 
 def find_index_section_limits(filename, section_start=".. toctree::\n",
                               section_end="\n"):
@@ -182,19 +189,20 @@ def find_index_section_limits(filename, section_start=".. toctree::\n",
     >>> index = '../../../../test_files/index_lfom.rst'
     >>> _, limits = find_index_section_limits(index)
     >>> limits
-    [[19, 26], [28, 32]]
+    [[18, 26], [27, 32]]
     >>> index = '../../../../test_files/index_ET.rst'
     >>> _, limits = find_index_section_limits(index)
     >>> limits
-    [[19, 26], [28, 33]]
+    [[18, 26], [27, 33]]
     """
     section_limits = []
     start = 0
     first_newline = True
     index_file = open(filename, "r+")
     lines = index_file.readlines()
+    index_file.close()
 
-    for i, line in enumerate(index_file):
+    for i, line in enumerate(lines):
         if line == section_start:
             start = i
         if line == section_end and start != 0:
@@ -205,8 +213,6 @@ def find_index_section_limits(filename, section_start=".. toctree::\n",
                 section_limits.append([start, end])
                 start = end = 0
                 first_newline = True
-
-    index_file.close()
 
     return lines, section_limits
 
@@ -224,7 +230,7 @@ def merge_indexes(new_index, old_index):
         none
 
     >>> old_index = '../../../../test_files/index_lfom.rst'
-    >>> new_index = '../../../../test_files/new_index.rst'
+    >>> new_index = '../../../../test_files/new_index_ET.rst'
     >>> merge_indexes(new_index, old_index)
     >>> index_file = open(old_index, "r+")
     >>> lines = index_file.readlines()
@@ -261,14 +267,14 @@ def merge_indexes(new_index, old_index):
 
     os.remove(new_index)
 
-def find_treatment_section_limits(filename, section_delimiter=".. heading"):
+def find_treatment_section_limits(filename, section_delimiter=".. _heading"):
     """Helper function for merge_treatment_processes which loops through the
     file and marks the beginning and end of each section.
 
     Args:
         filename: path to file to be modified
         section_delimiter: string which marks the separation between sections
-            Default: '.. heading'
+            Default: '.. _heading'
 
     Returns:
         lines: list of strings of each line in the file
@@ -278,25 +284,25 @@ def find_treatment_section_limits(filename, section_delimiter=".. heading"):
     >>> process = '../../../../test_files/Treatment_Process_ET.rst'
     >>> _, limits = find_treatment_section_limits(process)
     >>> limits
-    [[16, 21]]
+    [[0, 14], [15, 20]]
     >>> process = '../../../../test_files/Treatment_Process_ET_Floc.rst'
     >>> _, limits = find_treatment_section_limits(process)
     >>> limits
-    [[16, 21], [22, 27]]
+    [[0, 14], [15, 20], [21, 26]]
     """
     section_limits = []
     start = 0
     file = open(filename, "r+")
     lines = file.readlines()
+    file.close()
 
-    for i, line in enumerate(file):
+    for i, line in enumerate(lines):
         if section_delimiter in line:
             end = i - 1
             section_limits.append([start, end])
             start = i
 
     section_limits.append([start,len(lines)])
-    file.close()
 
     return lines, section_limits
 

--- a/aide_doc/form_submit/templates/docs/parse.py
+++ b/aide_doc/form_submit/templates/docs/parse.py
@@ -108,9 +108,12 @@ def parse_variables_from_list(unparsed):
 
     return measurement_list
 
-# TODO: complete section merging logic
 def merge_index_sections(new_section, old_section):
-    return new_section
+    for line in old_section:
+        if line in new_section:
+            continue
+        else:
+            new_section.append(line)
 
 def merge_indexes(new_index, old_index):
     section_start = ".. toctree::\n"
@@ -118,29 +121,41 @@ def merge_indexes(new_index, old_index):
 
     old_section_limits = []
     old_start = 0
-    new_section_limits = []
-    new_start = 0
-
     old_index_file = open(old_index, "r+")
     old_lines = old_index_file.readlines()
+
     for i, old_line in enumerate(old_index_file):
         if old_line == section_start:
             old_start = i
         if old_line == section_end and old_start != 0:
-            old_end = i
-            old_section_limits.append([old_start, old_end])
-            old_start = old_end = 0
+            if first_newline:
+                first_newline = False
+            else:
+                old_end = i
+                old_section_limits.append([old_start, old_end])
+                old_start = old_end = 0
+                first_newline = True
+
     old_index_file.close()
 
+    new_section_limits = []
+    new_start = 0
+    first_newline = True
     new_index_file = open(new_index, "r+")
     new_lines = new_index_file.readlines()
+
     for j, new_line in enumerate(new_index_file):
         if new_line == section_start:
             new_start = j
         if new_line == section_end and new_start != 0:
-            new_end = j
-            new_section_limits.append([new_start, new_end])
-            new_start = new_end = 0
+            if first_newline:
+                first_newline = False
+            else:
+                new_end = j
+                new_section_limits.append([new_start, new_end])
+                new_start = new_end = 0
+                first_newline = True
+
     new_index_file.close()
 
     for start, end in old_section_limits:
@@ -189,9 +204,9 @@ def parse_variables_from_map(unparsed, default_key):
         return parsed_variables, templates
     elif default_key == "process":
         # write function to download that process
-        # name it treatmentprocss.rst unless treatmentprocss.rst already exists
+        # name it treatmentprocess.rst unless treatmentproecss.rst already exists
         # if treatmentprocss.rst is not None:
-            # merge_treatment_processes(treatmentprocss.rst, newxprocess.rst
+            # merge_treatment_processes(treatmentprocess.rst, newprocess.rst
         if unparsed != "" and unparsed is not None:
             file = "Introduction/Treatment_Process.rst"
             file_path = "../../../../doc_files/Introduction/Treatment_Process_" + unparsed + ".rst"

--- a/aide_doc/form_submit/templates/docs/parse.py
+++ b/aide_doc/form_submit/templates/docs/parse.py
@@ -115,49 +115,35 @@ def merge_index_sections(new_section, old_section):
         else:
             new_section.append(line)
 
+def find_section_limits(file_name):
+    section_limits = []
+    start = 0
+    first_newline = True
+    index_file = open(file_name, "r+")
+    lines = index_file.readlines()
+
+    for i, line in enumerate(index_file):
+        if line == section_start:
+            start = i
+        if line == section_end and start != 0:
+            if first_newline:
+                first_newline = False
+            else:
+                end = i
+                section_limits.append([start, end])
+                start = end = 0
+                first_newline = True
+
+    index_file.close()
+
+    return lines, section_limits
+
 def merge_indexes(new_index, old_index):
     section_start = ".. toctree::\n"
     section_end = "\n"
 
-    old_section_limits = []
-    old_start = 0
-    first_newline = True
-    old_index_file = open(old_index, "r+")
-    old_lines = old_index_file.readlines()
-
-    for i, old_line in enumerate(old_index_file):
-        if old_line == section_start:
-            old_start = i
-        if old_line == section_end and old_start != 0:
-            if first_newline:
-                first_newline = False
-            else:
-                old_end = i
-                old_section_limits.append([old_start, old_end])
-                old_start = old_end = 0
-                first_newline = True
-
-    old_index_file.close()
-
-    new_section_limits = []
-    new_start = 0
-    first_newline = True
-    new_index_file = open(new_index, "r+")
-    new_lines = new_index_file.readlines()
-
-    for j, new_line in enumerate(new_index_file):
-        if new_line == section_start:
-            new_start = j
-        if new_line == section_end and new_start != 0:
-            if first_newline:
-                first_newline = False
-            else:
-                new_end = j
-                new_section_limits.append([new_start, new_end])
-                new_start = new_end = 0
-                first_newline = True
-
-    new_index_file.close()
+    old_lines, old_section_limits = find_section_limits(old_index)
+    new_lines, new_section_limits = find_section_limits(new_index)
 
     for start, end in old_section_limits:
         included = False

--- a/aide_doc/form_submit/templates/docs/parse.py
+++ b/aide_doc/form_submit/templates/docs/parse.py
@@ -108,20 +108,33 @@ def parse_variables_from_list(unparsed):
 
     return measurement_list
 
+def merge_indexes(new_index, old_index):
+    new_index_file = open(new_index, "w+")
+    old_index_file = open(old_index, "r+")
+    for old_line in old_index_file:
+        filename = os.path.basename(old_line.strip())
+        included = False
+        for new_line in new_index_file:
+            if filename in new_line:
+                included = True
+        # if not included:
+            # TODO: add functionality to insert in the correct location
+    old_index_file.close()
+    new_index_file.close()
+    os.remove(old_index)
+    copyfile(new_index, old_index)
+
 def parse_variables_from_map(unparsed, default_key):
     parsed_variables = {}
     value = None
 
     if default_key == "template":
-        # write function to download that rst for editing, or if possible, that folder
-        # might have to be a file path instead of url
         move_to_docs(unparsed)
     elif default_key == "index":
-        # write function to download that index
-        # name it index.rst unless index.rst already exists
-        # if index.rst is not None:
-            # merge_indexes(index.rst, newindex.rst)
-        if unparsed != "" and unparsed is not None:
+        if os.path.exists('index.rst'):
+            copyfile(unparsed, 'new_index.rst')
+            merge_indexes('new_index.rst', 'index.rst')
+        elif unparsed != "" and unparsed is not None:
             copyfile(unparsed, 'index.rst')
     elif default_key == "process":
         # write function to download that process
@@ -216,7 +229,6 @@ def get_parsed_measurements(link):
 
     return measurements
 
-# TODO: move this file and index file to "docs" folder
 # from https://stackoverflow.com/questions/5914627/prepend-line-to-beginning-of-a-file
 def line_prepender(filename, line):
     with open(filename, 'r+') as f:

--- a/aide_doc/form_submit/templates/docs/parse.py
+++ b/aide_doc/form_submit/templates/docs/parse.py
@@ -147,7 +147,7 @@ def parse_variables_from_list(unparsed):
 
 def merge_index_sections(new_section, old_section):
     """Helper function for merge_indexes which loops through each section and
-    combines them
+    combines them.
 
     Args:
         new_section: section which is being added to if line from old_section is absent
@@ -190,7 +190,7 @@ def find_index_section_limits(filename, section_start=".. toctree::\n",
     >>> _, limits = find_index_section_limits(index)
     >>> limits
     [[18, 26], [27, 32]]
-    >>> index = '../../../../test_files/index_ET.rst'
+    >>> index = '../../../../test_files/index_lfom_ET.rst'
     >>> _, limits = find_index_section_limits(index)
     >>> limits
     [[18, 26], [27, 33]]
@@ -485,7 +485,6 @@ def get_parsed_measurements(link):
         {
             return getAttributes(context, {
                 "entities" : qEverything(),
-                // "attributePattern" : { 'type' : 'Documenter' }
             });
         }
         """
@@ -533,7 +532,6 @@ def line_prepender(filename, line):
         f.seek(0, 0)
         f.write(line.rstrip('\r\n') + '\n' + content)
 
-# TODO: change name
 def make_replace_list(parsed_dict, filename, var_attachment=''):
     """Adds the dictionary of variables which have been parsed to the top of the
     given file.
@@ -546,6 +544,16 @@ def make_replace_list(parsed_dict, filename, var_attachment=''):
 
     Returns:
         none
+
+    >>> var_dict = {'test': '3.0 cm'}
+    >>> file_path = "../../../../test_files/test_prepend.rst"
+    >>> make_replace_list(var_dict, file_path)
+    >>> file = open(file_path, "r+")
+    >>> lines = file.readlines()
+    >>> test_file = open('../../../../test_files/test_prepend_result.rst')
+    >>> test_lines = test_file.readlines()
+    >>> test_lines == lines
+    True
     """
     prefix = '.. |'
     suffix = '| replace:: '

--- a/aide_doc/form_submit/templates/docs/settings.py
+++ b/aide_doc/form_submit/templates/docs/settings.py
@@ -1,2 +1,2 @@
 language = 'es'
-link = 'https://cad.onshape.com/documents/c3a8ce032e33ebe875b9aab4/w/aee435fcf42dc668f3fd6a2c/e/d75b2f7a41dde39791b154e8'
+link = 'https://cad.onshape.com/documents/c3a8ce032e33ebe875b9aab4/w/6adcfdb3748954c1c2b7d1b2/e/e09d11406e7a9143537efe3a'

--- a/aide_doc/manage.py
+++ b/aide_doc/manage.py
@@ -17,5 +17,6 @@ def main():
     execute_from_command_line(sys.argv)
 
 # running locally: https://cloud.google.com/python/django/appengine
+# python manage.py runserver
 if __name__ == '__main__':
     main()

--- a/doc_files/Entrance_Tank/Tank_Design_Algorithm.rst
+++ b/doc_files/Entrance_Tank/Tank_Design_Algorithm.rst
@@ -1,4 +1,3 @@
-.. include:: ../global.rst
 
 .. _title_Tank_Algoritmo_de_Diseño:
 

--- a/doc_files/Introduction/Treatment_Process_Floc.rst
+++ b/doc_files/Introduction/Treatment_Process_Floc.rst
@@ -1,0 +1,20 @@
+.. _title_Procesos_de_Tratamiento:
+
+***********************
+Procesos de Tratamiento
+***********************
+Las plantas producen agua limpia y segura, tras la remoción de sedimentos y patógenos. La tecnología AguaClara emplea los procesos unitarios de coagulación, floculación, sedimentación, filtración rápida con arena, y desinfección con cloro (:numref:`figure_process`).
+
+.. _figure_process:
+
+.. figure:: Images/process.png
+    :width: 650px
+    :align: center
+
+    Los procesos de tratamiento que se utilizan en la planta AguaClara.
+
+.. _heading_floculación:
+
+Floculación
+-----------
+Luego la mezcla de agua y coagulante entra en el **floculador**, una serie de canales con deflectores que dirigen el flujo de agua. La mezcla suave en el flujo del floculador promueve choques entre partículas, y estas se quedan pegadas por el efecto de las nanopartículas del coagulante. Durante este proceso, que se llama la floculación, las partículas crecen, formando aglomeraciones (**flóculos**). Al final han alcanzado un tamaño visible, y tienen una velocidad terminal suficiente alta para eliminarse en el siguiente proceso, la **sedimentación**.

--- a/doc_files/index_ET.rst
+++ b/doc_files/index_ET.rst
@@ -29,7 +29,6 @@ Este documento está escrito y mantenido en `Github <https://github.com/AguaClar
   :caption: Tanque de Entrada
   :maxdepth: 1
 
-  Entrance_Tank/LFOM.rst
   Entrance_Tank/Tank_Design_Algorithm.rst
 
 `Las versiones de PDF y LaTeX <https://github.com/AguaClara/aide_design_specs/releases/latest>`_ [#pdf_warning]_.

--- a/doc_files/index_ET.rst
+++ b/doc_files/index_ET.rst
@@ -1,0 +1,39 @@
+.. _toc:
+
+===============
+Memoria Tecnica
+===============
+Este documento está escrito y mantenido en `Github <https://github.com/AguaClara/aide_design_specs>`_ via `Sphinx <http://www.sphinx-doc.org/en/master/>`_. Utiliza y se refiere a código y funciones de AguaClara en `AguaClara <https://github.com/AguaClara/aguaclara>`_. A continuación se enumeran las versiones de los programas que utilizamos:
+
+.. _software_versions:
+.. csv-table:: Estas son las versiones de software utilizadas para compilar esta documentación.
+   :header: "Software", "version"
+   :widths: 10, 10
+   :align: center
+
+   "Sphinx", "1.7.5"
+   "aguaclara", "0.1.8"
+   "Anaconda", "4.5.4"
+   "Python", "3.6.5"
+
+.. toctree::
+  :caption: Introducción a la Tecnología AguaClara
+  :maxdepth: 1
+
+  Introduction/History.rst
+  Introduction/Treatment_Process.rst
+  Introduction/Requirements.rst
+  Introduction/AIDE_Tools.rst
+
+.. toctree::
+  :caption: Tanque de Entrada
+  :maxdepth: 1
+
+  Entrance_Tank/LFOM.rst
+  Entrance_Tank/Tank_Design_Algorithm.rst
+
+`Las versiones de PDF y LaTeX <https://github.com/AguaClara/aide_design_specs/releases/latest>`_ [#pdf_warning]_.
+
+.. rubric:: **Notas**
+
+.. [#pdf_warning] Las versiones de PDF y LaTeX pueden contener rarezas visuales porque se genera automáticamente. El sitio web es la forma recomendada de leer este documento. `Por favor visite nuestro GitHub <https://github.com/AguaClara/aide_design_specs>`_ para enviar un problema, contribuir o comentar.

--- a/test_files/Treatment_Process_ET.rst
+++ b/test_files/Treatment_Process_ET.rst
@@ -1,0 +1,20 @@
+.. _title_Procesos_de_Tratamiento:
+
+***********************
+Procesos de Tratamiento
+***********************
+Las plantas producen agua limpia y segura, tras la remoción de sedimentos y patógenos. La tecnología AguaClara emplea los procesos unitarios de coagulación, floculación, sedimentación, filtración rápida con arena, y desinfección con cloro (:numref:`figure_process`).
+
+.. _figure_process:
+
+.. figure:: Images/process.png
+    :width: 650px
+    :align: center
+
+    Los procesos de tratamiento que se utilizan en la planta AguaClara.
+
+.. _heading_el_tanque_de_entrada:
+
+El tanque de entrada
+--------------------
+El proceso inicia en el **tanque de entrada**, que sirve tanto para quitar del agua el material grueso como para medir el caudal de agua para la dosificación de los químicos. El tanque de entrada funciona como tanque de sedimentación en que las partículas gruesas se caen al fondo del tanque por gravedad. Debido al diseño especial de la salida, el nivel de agua en el tanque varía en proporción al caudal de agua en la planta. Este nivel de agua está conectado con el sistema semi-automático de dosificación de químicos, de tal forma que las dosis del coagulante y del cloro se mantienen aun cuando cambia el caudal de agua en la planta. Mediante el dosificador de químicos, en la salida del tanque de entrada se aplica un coagulante, que se une con el agua cruda en la **mezcla rápida**.

--- a/test_files/Treatment_Process_ET_Floc.rst
+++ b/test_files/Treatment_Process_ET_Floc.rst
@@ -1,0 +1,26 @@
+.. _title_Procesos_de_Tratamiento:
+
+***********************
+Procesos de Tratamiento
+***********************
+Las plantas producen agua limpia y segura, tras la remoción de sedimentos y patógenos. La tecnología AguaClara emplea los procesos unitarios de coagulación, floculación, sedimentación, filtración rápida con arena, y desinfección con cloro (:numref:`figure_process`).
+
+.. _figure_process:
+
+.. figure:: Images/process.png
+    :width: 650px
+    :align: center
+
+    Los procesos de tratamiento que se utilizan en la planta AguaClara.
+
+.. _heading_el_tanque_de_entrada:
+
+El tanque de entrada
+--------------------
+El proceso inicia en el **tanque de entrada**, que sirve tanto para quitar del agua el material grueso como para medir el caudal de agua para la dosificación de los químicos. El tanque de entrada funciona como tanque de sedimentación en que las partículas gruesas se caen al fondo del tanque por gravedad. Debido al diseño especial de la salida, el nivel de agua en el tanque varía en proporción al caudal de agua en la planta. Este nivel de agua está conectado con el sistema semi-automático de dosificación de químicos, de tal forma que las dosis del coagulante y del cloro se mantienen aun cuando cambia el caudal de agua en la planta. Mediante el dosificador de químicos, en la salida del tanque de entrada se aplica un coagulante, que se une con el agua cruda en la **mezcla rápida**.
+
+.. _heading_floculación:
+
+Floculación
+-----------
+Luego la mezcla de agua y coagulante entra en el **floculador**, una serie de canales con deflectores que dirigen el flujo de agua. La mezcla suave en el flujo del floculador promueve choques entre partículas, y estas se quedan pegadas por el efecto de las nanopartículas del coagulante. Durante este proceso, que se llama la floculación, las partículas crecen, formando aglomeraciones (**flóculos**). Al final han alcanzado un tamaño visible, y tienen una velocidad terminal suficiente alta para eliminarse en el siguiente proceso, la **sedimentación**.

--- a/test_files/Treatment_Process_Floc.rst
+++ b/test_files/Treatment_Process_Floc.rst
@@ -1,0 +1,20 @@
+.. _title_Procesos_de_Tratamiento:
+
+***********************
+Procesos de Tratamiento
+***********************
+Las plantas producen agua limpia y segura, tras la remoción de sedimentos y patógenos. La tecnología AguaClara emplea los procesos unitarios de coagulación, floculación, sedimentación, filtración rápida con arena, y desinfección con cloro (:numref:`figure_process`).
+
+.. _figure_process:
+
+.. figure:: Images/process.png
+    :width: 650px
+    :align: center
+
+    Los procesos de tratamiento que se utilizan en la planta AguaClara.
+
+.. _heading_floculación:
+
+Floculación
+-----------
+Luego la mezcla de agua y coagulante entra en el **floculador**, una serie de canales con deflectores que dirigen el flujo de agua. La mezcla suave en el flujo del floculador promueve choques entre partículas, y estas se quedan pegadas por el efecto de las nanopartículas del coagulante. Durante este proceso, que se llama la floculación, las partículas crecen, formando aglomeraciones (**flóculos**). Al final han alcanzado un tamaño visible, y tienen una velocidad terminal suficiente alta para eliminarse en el siguiente proceso, la **sedimentación**.

--- a/test_files/index_ET.rst
+++ b/test_files/index_ET.rst
@@ -29,7 +29,6 @@ Este documento está escrito y mantenido en `Github <https://github.com/AguaClar
   :caption: Tanque de Entrada
   :maxdepth: 1
 
-  Entrance_Tank/LFOM.rst
   Entrance_Tank/Tank_Design_Algorithm.rst
 
 `Las versiones de PDF y LaTeX <https://github.com/AguaClara/aide_design_specs/releases/latest>`_ [#pdf_warning]_.

--- a/test_files/index_ET.rst
+++ b/test_files/index_ET.rst
@@ -1,0 +1,39 @@
+.. _toc:
+
+===============
+Memoria Tecnica
+===============
+Este documento está escrito y mantenido en `Github <https://github.com/AguaClara/aide_design_specs>`_ via `Sphinx <http://www.sphinx-doc.org/en/master/>`_. Utiliza y se refiere a código y funciones de AguaClara en `AguaClara <https://github.com/AguaClara/aguaclara>`_. A continuación se enumeran las versiones de los programas que utilizamos:
+
+.. _software_versions:
+.. csv-table:: Estas son las versiones de software utilizadas para compilar esta documentación.
+   :header: "Software", "version"
+   :widths: 10, 10
+   :align: center
+
+   "Sphinx", "1.7.5"
+   "aguaclara", "0.1.8"
+   "Anaconda", "4.5.4"
+   "Python", "3.6.5"
+
+.. toctree::
+  :caption: Introducción a la Tecnología AguaClara
+  :maxdepth: 1
+
+  Introduction/History.rst
+  Introduction/Treatment_Process.rst
+  Introduction/Requirements.rst
+  Introduction/AIDE_Tools.rst
+
+.. toctree::
+  :caption: Tanque de Entrada
+  :maxdepth: 1
+
+  Entrance_Tank/LFOM.rst
+  Entrance_Tank/Tank_Design_Algorithm.rst
+
+`Las versiones de PDF y LaTeX <https://github.com/AguaClara/aide_design_specs/releases/latest>`_ [#pdf_warning]_.
+
+.. rubric:: **Notas**
+
+.. [#pdf_warning] Las versiones de PDF y LaTeX pueden contener rarezas visuales porque se genera automáticamente. El sitio web es la forma recomendada de leer este documento. `Por favor visite nuestro GitHub <https://github.com/AguaClara/aide_design_specs>`_ para enviar un problema, contribuir o comentar.

--- a/test_files/index_lfom.rst
+++ b/test_files/index_lfom.rst
@@ -1,0 +1,38 @@
+.. _toc:
+
+===============
+Memoria Tecnica
+===============
+Este documento está escrito y mantenido en `Github <https://github.com/AguaClara/aide_design_specs>`_ via `Sphinx <http://www.sphinx-doc.org/en/master/>`_. Utiliza y se refiere a código y funciones de AguaClara en `AguaClara <https://github.com/AguaClara/aguaclara>`_. A continuación se enumeran las versiones de los programas que utilizamos:
+
+.. _software_versions:
+.. csv-table:: Estas son las versiones de software utilizadas para compilar esta documentación.
+   :header: "Software", "version"
+   :widths: 10, 10
+   :align: center
+
+   "Sphinx", "1.7.5"
+   "aguaclara", "0.1.8"
+   "Anaconda", "4.5.4"
+   "Python", "3.6.5"
+
+.. toctree::
+  :caption: Introducción a la Tecnología AguaClara
+  :maxdepth: 1
+
+  Introduction/History.rst
+  Introduction/Treatment_Process.rst
+  Introduction/Requirements.rst
+  Introduction/AIDE_Tools.rst
+
+.. toctree::
+  :caption: Tanque de Entrada
+  :maxdepth: 1
+
+  Entrance_Tank/LFOM.rst
+
+`Las versiones de PDF y LaTeX <https://github.com/AguaClara/aide_design_specs/releases/latest>`_ [#pdf_warning]_.
+
+.. rubric:: **Notas**
+
+.. [#pdf_warning] Las versiones de PDF y LaTeX pueden contener rarezas visuales porque se genera automáticamente. El sitio web es la forma recomendada de leer este documento. `Por favor visite nuestro GitHub <https://github.com/AguaClara/aide_design_specs>`_ para enviar un problema, contribuir o comentar.

--- a/test_files/index_lfom_ET.rst
+++ b/test_files/index_lfom_ET.rst
@@ -29,8 +29,8 @@ Este documento está escrito y mantenido en `Github <https://github.com/AguaClar
   :caption: Tanque de Entrada
   :maxdepth: 1
 
-  Entrance_Tank/LFOM.rst
   Entrance_Tank/Tank_Design_Algorithm.rst
+  Entrance_Tank/LFOM.rst
 
 `Las versiones de PDF y LaTeX <https://github.com/AguaClara/aide_design_specs/releases/latest>`_ [#pdf_warning]_.
 

--- a/test_files/index_lfom_ET.rst
+++ b/test_files/index_lfom_ET.rst
@@ -1,0 +1,39 @@
+.. _toc:
+
+===============
+Memoria Tecnica
+===============
+Este documento está escrito y mantenido en `Github <https://github.com/AguaClara/aide_design_specs>`_ via `Sphinx <http://www.sphinx-doc.org/en/master/>`_. Utiliza y se refiere a código y funciones de AguaClara en `AguaClara <https://github.com/AguaClara/aguaclara>`_. A continuación se enumeran las versiones de los programas que utilizamos:
+
+.. _software_versions:
+.. csv-table:: Estas son las versiones de software utilizadas para compilar esta documentación.
+   :header: "Software", "version"
+   :widths: 10, 10
+   :align: center
+
+   "Sphinx", "1.7.5"
+   "aguaclara", "0.1.8"
+   "Anaconda", "4.5.4"
+   "Python", "3.6.5"
+
+.. toctree::
+  :caption: Introducción a la Tecnología AguaClara
+  :maxdepth: 1
+
+  Introduction/History.rst
+  Introduction/Treatment_Process.rst
+  Introduction/Requirements.rst
+  Introduction/AIDE_Tools.rst
+
+.. toctree::
+  :caption: Tanque de Entrada
+  :maxdepth: 1
+
+  Entrance_Tank/LFOM.rst
+  Entrance_Tank/Tank_Design_Algorithm.rst
+
+`Las versiones de PDF y LaTeX <https://github.com/AguaClara/aide_design_specs/releases/latest>`_ [#pdf_warning]_.
+
+.. rubric:: **Notas**
+
+.. [#pdf_warning] Las versiones de PDF y LaTeX pueden contener rarezas visuales porque se genera automáticamente. El sitio web es la forma recomendada de leer este documento. `Por favor visite nuestro GitHub <https://github.com/AguaClara/aide_design_specs>`_ para enviar un problema, contribuir o comentar.

--- a/test_files/new_index_ET.rst
+++ b/test_files/new_index_ET.rst
@@ -29,7 +29,6 @@ Este documento está escrito y mantenido en `Github <https://github.com/AguaClar
   :caption: Tanque de Entrada
   :maxdepth: 1
 
-  Entrance_Tank/LFOM.rst
   Entrance_Tank/Tank_Design_Algorithm.rst
 
 `Las versiones de PDF y LaTeX <https://github.com/AguaClara/aide_design_specs/releases/latest>`_ [#pdf_warning]_.

--- a/test_files/new_index_ET.rst
+++ b/test_files/new_index_ET.rst
@@ -1,0 +1,39 @@
+.. _toc:
+
+===============
+Memoria Tecnica
+===============
+Este documento está escrito y mantenido en `Github <https://github.com/AguaClara/aide_design_specs>`_ via `Sphinx <http://www.sphinx-doc.org/en/master/>`_. Utiliza y se refiere a código y funciones de AguaClara en `AguaClara <https://github.com/AguaClara/aguaclara>`_. A continuación se enumeran las versiones de los programas que utilizamos:
+
+.. _software_versions:
+.. csv-table:: Estas son las versiones de software utilizadas para compilar esta documentación.
+   :header: "Software", "version"
+   :widths: 10, 10
+   :align: center
+
+   "Sphinx", "1.7.5"
+   "aguaclara", "0.1.8"
+   "Anaconda", "4.5.4"
+   "Python", "3.6.5"
+
+.. toctree::
+  :caption: Introducción a la Tecnología AguaClara
+  :maxdepth: 1
+
+  Introduction/History.rst
+  Introduction/Treatment_Process.rst
+  Introduction/Requirements.rst
+  Introduction/AIDE_Tools.rst
+
+.. toctree::
+  :caption: Tanque de Entrada
+  :maxdepth: 1
+
+  Entrance_Tank/LFOM.rst
+  Entrance_Tank/Tank_Design_Algorithm.rst
+
+`Las versiones de PDF y LaTeX <https://github.com/AguaClara/aide_design_specs/releases/latest>`_ [#pdf_warning]_.
+
+.. rubric:: **Notas**
+
+.. [#pdf_warning] Las versiones de PDF y LaTeX pueden contener rarezas visuales porque se genera automáticamente. El sitio web es la forma recomendada de leer este documento. `Por favor visite nuestro GitHub <https://github.com/AguaClara/aide_design_specs>`_ para enviar un problema, contribuir o comentar.

--- a/test_files/test_prepend.rst
+++ b/test_files/test_prepend.rst
@@ -1,0 +1,7 @@
+
+.. _title_Procesos_de_Tratamiento:
+
+***********************
+Procesos de Tratamiento
+***********************
+Las plantas producen agua limpia y segura, tras la remoción de sedimentos y patógenos. La tecnología AguaClara emplea los procesos unitarios de coagulación, floculación, sedimentación, filtración rápida con arena, y desinfección con cloro (:numref:`figure_process`).

--- a/test_files/test_prepend_result.rst
+++ b/test_files/test_prepend_result.rst
@@ -1,0 +1,8 @@
+.. |test| replace:: 3.0 cm
+
+.. _title_Procesos_de_Tratamiento:
+
+***********************
+Procesos de Tratamiento
+***********************
+Las plantas producen agua limpia y segura, tras la remoción de sedimentos y patógenos. La tecnología AguaClara emplea los procesos unitarios de coagulación, floculación, sedimentación, filtración rápida con arena, y desinfección con cloro (:numref:`figure_process`).


### PR DESCRIPTION
I completed functionality to merge the different `index.rst` which exist for the LFOM and entrance tank. The same functionality was introduced for `Treatment_Process.rst`.

This is accomplished by comparing the two files, `index.rst` and `new_index.rst` section by section and adding pieces which exist in `index.rst` but are missing from `new_index.rst` . At the end, the one which was added to is maintained as `index.rst` and `new_index.rst` is deleted.

In the future the efficiency of the algorithm can definitely be improved. More complex tests are required as well to ensure edge cases aren't missing.

Closes #25, Closes #30 